### PR TITLE
add group name to project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'jacoco'
 
+group = 'de.beosign'
 version = '1.1.0'
 
 check.dependsOn jacocoTestReport


### PR DESCRIPTION
Since this project doesn't yet exist in mavenCentral, it would be helpful to add a group name to the project. Having a proper group name allows other projects to reference just the github repository as a dependency.

If using this project, then you add the following to your projects settings.gradle
```
sourceControl {
    gitRepository("https://github.com/beosign/snakeyaml-anno.git") {
        producesModule("de.beosign:snakeyamlanno")
    }
}
```

And add this to that projects build.gradle
```
dependencies {
...
   implementation 'de.beosign:snakeyamlanno:1.1.0'
...
}
```

OR if a tag doesn't exist, then reference a branch...
```
dependencies {
...
   implementation('de.beosign:snakeyamlanno') {
        version {
            branch = 'add_group_name'
        }
   }
...
}
```