### PR TITLE
Gradle: change declaring versions' ranges to maven style and cleanup dependencies 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,15 +33,13 @@ sourceCompatibility=1.8
 targetCompatibility=1.8
 
 dependencies {
-        //gradle maven plugin is not translating "+" to [X,)
+    //gradle maven plugin is not translating "+" to [X,)
 	compile 'org.yaml:snakeyaml:1.26'
-	compile 'org.slf4j:slf4j-api:[1.7.0,)'
   	compile 'org.apache.commons:commons-lang3:[3.0,)'
-  	compile 'commons-io:commons-io:2.6'
-  	compile 'commons-beanutils:commons-beanutils:[1.9.0,)'
   	
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.6.+'
     testCompile 'org.hamcrest:hamcrest-all:1.3'
+    testCompile 'org.slf4j:slf4j-api:1.7.+'
     testCompile 'org.apache.logging.log4j:log4j-api:2.9.+'
     testCompile 'org.apache.logging.log4j:log4j-core:2.9.+'
     testCompile 'org.apache.logging.log4j:log4j-slf4j-impl:2.9.+'

--- a/build.gradle
+++ b/build.gradle
@@ -33,14 +33,15 @@ sourceCompatibility=1.8
 targetCompatibility=1.8
 
 dependencies {
+        //gradle maven plugin is not translating "+" to [X,)
 	compile 'org.yaml:snakeyaml:1.26'
-	compile 'org.slf4j:slf4j-api:1.7.+'
-  	compile 'org.apache.commons:commons-lang3:3.+'
+	compile 'org.slf4j:slf4j-api:[1.7.0,)'
+  	compile 'org.apache.commons:commons-lang3:[3.0,)'
   	compile 'commons-io:commons-io:2.6'
-  	compile 'commons-beanutils:commons-beanutils:1.9.+'
+  	compile 'commons-beanutils:commons-beanutils:[1.9.0,)'
   	
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.6.+'
-	testCompile 'org.hamcrest:hamcrest-all:1.3'
+    testCompile 'org.hamcrest:hamcrest-all:1.3'
     testCompile 'org.apache.logging.log4j:log4j-api:2.9.+'
     testCompile 'org.apache.logging.log4j:log4j-core:2.9.+'
     testCompile 'org.apache.logging.log4j:log4j-slf4j-impl:2.9.+'

--- a/src/main/java/de/beosign/snakeyamlanno/constructor/AnnotationAwareConstructor.java
+++ b/src/main/java/de/beosign/snakeyamlanno/constructor/AnnotationAwareConstructor.java
@@ -11,8 +11,6 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import org.apache.commons.lang3.ClassUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.constructor.Construct;
 import org.yaml.snakeyaml.constructor.Constructor;
@@ -40,11 +38,10 @@ import de.beosign.snakeyamlanno.property.YamlProperty;
  * @author florian
  */
 public class AnnotationAwareConstructor extends Constructor {
-    private static final Logger log = LoggerFactory.getLogger(AnnotationAwareConstructor.class);
 
-    private Map<Class<?>, YamlConstructBy> constructByMap = new HashMap<>();
-    private Map<Class<?>, YamlInstantiateBy> instantiateByMap = new HashMap<>();
-    private IdentityHashMap<Node, Property> nodeToPropertyMap = new IdentityHashMap<>();
+    private final Map<Class<?>, YamlConstructBy> constructByMap = new HashMap<>();
+    private final Map<Class<?>, YamlInstantiateBy> instantiateByMap = new HashMap<>();
+    private final IdentityHashMap<Node, Property> nodeToPropertyMap = new IdentityHashMap<>();
     private GlobalInstantiator globalInstantiator = new DefaultGlobalInstantiator();
 
     /**
@@ -197,7 +194,6 @@ public class AnnotationAwareConstructor extends Constructor {
                             Construct constructor = getConstructor(valueNode);
                             constructor.construct(valueNode);
                         } catch (Exception e) {
-                            log.debug("Ignore: Could not construct property {}.{}: {}", beanType, key, e.getMessage());
                             nodeTuplesToBeRemoved.add(tuple);
                         }
                     }

--- a/src/main/java/de/beosign/snakeyamlanno/constructor/AnnotationAwareListConstructor.java
+++ b/src/main/java/de/beosign/snakeyamlanno/constructor/AnnotationAwareListConstructor.java
@@ -4,8 +4,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.SequenceNode;
 import org.yaml.snakeyaml.nodes.Tag;
@@ -18,7 +16,6 @@ import org.yaml.snakeyaml.nodes.Tag;
  * @since 0.8.0
  */
 public class AnnotationAwareListConstructor extends AnnotationAwareConstructor {
-    private static final Logger log = LoggerFactory.getLogger(AnnotationAwareListConstructor.class);
 
     private final Class<?> collectionItemType;
 
@@ -51,7 +48,6 @@ public class AnnotationAwareListConstructor extends AnnotationAwareConstructor {
     @Override
     public Object getSingleData(Class<?> type) {
         if (Collection.class.isAssignableFrom(type)) {
-            log.debug("Found a collection type as root node; set type of item nodes to " + collectionItemType.getTypeName());
             SequenceNode node = (SequenceNode) composer.getSingleNode();
             node.setTag(new Tag(type));
             for (Node n : node.getValue()) {


### PR DESCRIPTION
This lib is really cool and helpful, so I think it has large potential even at maven projects.
I am using it, but there are maven warrning accroding to "+" sing in version:

![image](https://user-images.githubusercontent.com/25181517/112720404-673fbd80-8efe-11eb-921c-56d74e8792b4.png)

The pom.xml file generated in your lib with gradle maven plugin is not replacing "+". 

![image](https://user-images.githubusercontent.com/25181517/112720466-c7cefa80-8efe-11eb-9d6b-9a052c190c83.png)

From: https://docs.gradle.org/current/userguide/single_versions.html I know that gradle support both: + and [,) so I think the change will be helpful and will make this lib more popular
